### PR TITLE
fix: using :cka_class attributes with binary values led to infinite loop

### DIFF
--- a/c_src/p11ex_nif.c
+++ b/c_src/p11ex_nif.c
@@ -3852,7 +3852,7 @@ static int object_class_from_term(ErlNifEnv* env, ERL_NIF_TERM term, CK_OBJECT_C
   char atom[MAX_OBJECT_CLASS_NAME_LENGTH];
 
   if (enif_get_atom(env, term, atom, sizeof(atom), ERL_NIF_UTF8) <= 0) {
-    return -1; /* term value is not an atom */
+    return -2; /* term value is not an atom */
   }
 
   for (const object_class_map_t *m = object_class_map; m->name != NULL; m++) {

--- a/test/p11ex/attr_test.exs
+++ b/test/p11ex/attr_test.exs
@@ -1,0 +1,18 @@
+defmodule P11ExTest.AttrTest do
+
+  use ExUnit.Case, async: false
+
+  alias P11ex.Session, as: Session
+
+  @moduletag :attr
+
+  setup_all do
+    P11ex.TestHelper.setup_session()
+  end
+
+  test "attibute: cka_class with wrong argument", context do
+    {:error, :invalid_attribute_value, :cka_class} =
+      Session.find_objects(context.session_pid, [{:cka_class, "pubk"}], 10)
+  end
+
+end


### PR DESCRIPTION
Fix: The translation for {:cka_class, "pubk"} to attributes led to an infinite loop